### PR TITLE
Handle metric strings with whitespace properly

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,6 +100,20 @@ mod tests {
     }
 
     #[test]
+    fn test_statsd_counter_newline() {
+        let expected = Message {
+            name: "gorets".to_string(),
+            tags: None,
+            metric: Metric::Counter(Counter {
+                value: 1.0,
+                sample_rate: None,
+            })
+        };
+
+        assert_eq!(parse("gorets:1|c\n"), Ok(expected));
+    }
+
+    #[test]
     fn test_statsd_gauge() {
         let expected = Message {
             name: "gorets".to_string(),

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -53,7 +53,7 @@ pub struct Parser {
 impl Parser {
     // Returns a Parser for given string
     pub fn new(buf: String) -> Parser {
-        let chars: Vec<char> = buf.chars().collect();
+        let chars: Vec<char> = buf.trim_end().chars().collect();
         let len = chars.len();
         Parser {
             chars: chars,


### PR DESCRIPTION
When reading directly off a socket, the statsd message will come in with a
newline at the end. This ensures that the buffer can be passed directly into the
parser without issue